### PR TITLE
Fixed matter update of door lock state

### DIFF
--- a/doorlock.js
+++ b/doorlock.js
@@ -49,8 +49,6 @@ module.exports = function(RED) {
                      }
                      break
                  default:
-                node.pending = true
-                node.pendingmsg = msg
                 if (msg.payload.state == undefined || typeof(msg.payload) != "object"){
                     msg.payload = state = {state: msg.payload}
                 }


### PR DESCRIPTION
Pending flag should not be set to true by default. See onoff.js.