### PR TITLE
Fix on off socket

### DIFF
--- a/humiditysensor.html
+++ b/humiditysensor.html
@@ -48,7 +48,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="matterhumiditysensor">
-    <p>A Bridged Light Sensor</p>
+    <p>A Bridged Humidity Sensor</p>
 
     <h3>Inputs</h3>
         <dl class="message-properties">
@@ -59,7 +59,7 @@
                  </span>
              </dt>
              <dd> 
-                 The humidity in percent  between the configured min and max values.
+                 The humidity in percent between the configured min and max values.
                  Matter supports up to 2 decmimal places of precision.
 
              </dd>

--- a/onoffsocket.html
+++ b/onoffsocket.html
@@ -31,15 +31,15 @@
     </div>
     <div class="form-row">
         <label for="node-input-passthrough">Passthrough Input msg to Output</label>
-        <select type="text" id="node-input-passthrough" style="width:50%;" >
+        <select type="text" id="node-input-passthrough" style="width:50%;">
             <option value=true>True</option>
-            <option value=false>False</option>
+            <option value=false selected>False</option>
         </select>
     </div>
     <div class="form-row">
         <label for="node-input-bat">Battery</label>
-        <select type="text" id="node-input-bat" style="width:50%;" >
-            <option value=false>None</option>
+        <select type="text" id="node-input-bat" style="width:50%;">
+            <option value=false selected>None</option>
             <option value="recharge">Rechargeable</option>
             <option value="replace">Replaceable</option>
         </select>

--- a/onoffsocket.js
+++ b/onoffsocket.js
@@ -72,7 +72,7 @@ module.exports = function(RED) {
                         }
                     }
                     //If values are changed then set them & wait for callback otherwise send msg on
-                    if (willUpdate.call(node.device, newData)) {
+                    if (typeof newData?.onOff?.onOff === 'boolean' && willUpdate.call(node.device, newData)) {
                         node.debug(`WILL update, ${newData}`)
                         node.pending = true
                         node.pendingmsg = msg

--- a/pressuresensor.html
+++ b/pressuresensor.html
@@ -48,7 +48,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="matterpressuresensor">
-    <p>A Bridged Light Sensor</p>
+    <p>A Bridged Pressure Sensor</p>
 
     <h3>Inputs</h3>
         <dl class="message-properties">
@@ -59,7 +59,7 @@
                  </span>
              </dt>
              <dd> 
-                 The pressue in kPa  between the configured min and max values.
+                 The pressue in kPa between the configured min and max values.
                  Matter supports up to 1 decmimal place of precision.
 
              </dd>

--- a/temperaturesensor.html
+++ b/temperaturesensor.html
@@ -48,7 +48,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="mattertemperaturesensor">
-    <p>A Bridged Light Sensor</p>
+    <p>A Bridged Temperature Sensor</p>
 
     <h3>Inputs</h3>
         <dl class="message-properties">


### PR DESCRIPTION
I haven't tested this locally, as I'll need to run NodeRed on my dev machine, but I believe this fixes https://github.com/sammachin/node-red-matter-bridge/issues/50

The crash happens when there's no value set for battery or passthrough values, so I set defaults for those on the node. I also noticed that if you send it invalid data (like a boolean, instead of a proper `{state:"on"}` object it also crashes, so i added in a type check before it's passed on.

If it works it could probably be added to the `willUpdate` function in utils, or at least added to some more nodes, to avoid Matter crashing NodeRed.